### PR TITLE
Workaround for file://con use of stdin on Windows

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -450,6 +450,9 @@ int main(int argc, char** argv)
     size_t lastReportedtLostBytes = 0;
     std::time_t writeErrorLogTimer(std::time(nullptr));
 
+    UriParser::Type srcUriType = UriParser::Type::UNKNOWN;
+    bool srcReadMore = false;
+
     try {
         // Now loop until broken
         while (!int_state && !timer_state)
@@ -463,7 +466,8 @@ int main(int argc, char** argv)
                     return 1;
                 }
                 int events = SRT_EPOLL_IN | SRT_EPOLL_ERR;
-                switch (src->uri.type())
+                srcUriType = src->uri.type();
+                switch (srcUriType)
                 {
                 case UriParser::SRT:
                     if (srt_epoll_add_usock(pollid,
@@ -538,8 +542,8 @@ int main(int argc, char** argv)
             SYSSOCKET sysrfds[2];
             if (srt_epoll_wait(pollid,
                 &srtrwfds[0], &srtrfdslen, &srtrwfds[2], &srtwfdslen,
-                100,
-                &sysrfds[0], &sysrfdslen, 0, 0) >= 0)
+                (srcReadMore ? 0 : 100),
+                &sysrfds[0], &sysrfdslen, 0, 0) >= 0 || srcReadMore)
             {
                 bool doabort = false;
                 for (size_t i = 0; i < sizeof(srtrwfds) / sizeof(SRTSOCKET); i++)
@@ -708,7 +712,8 @@ int main(int argc, char** argv)
                 std::list<std::shared_ptr<bytevector>> dataqueue;
                 if (src.get() && (srtrfdslen || sysrfdslen))
                 {
-                    while (dataqueue.size() < 10)
+                    size_t srcChunksToRead = 10;
+                    while (dataqueue.size() < srcChunksToRead)
                     {
                         std::shared_ptr<bytevector> pdata(
                             new bytevector(cfg.chunk_size));
@@ -719,6 +724,15 @@ int main(int argc, char** argv)
                         dataqueue.push_back(pdata);
                         receivedBytes += (*pdata).size();
                     }
+
+#ifdef _WIN32
+                    srcReadMore = false;
+                    // Check if read up to max number of chunks from stdin
+                    if (srcUriType == UriParser::Type::FILE && dataqueue.size() >= srcChunksToRead)
+                    {
+                        srcReadMore = true;
+                    }
+#endif
                 }
 
                 // if no target, let received data fall to the floor


### PR DESCRIPTION
Workaround of issue found on Windows when using "file://con" for input to
`srt-live-transmit.exe` -- only 1st 13160 bytes of data was being read from stdin.